### PR TITLE
🚑 ⬇️ Downgrades adb to 7.0.0+r33-2

### DIFF
--- a/adb/Dockerfile
+++ b/adb/Dockerfile
@@ -11,7 +11,11 @@ RUN \
     apt-get update \
     \
     && apt-get install -y --no-install-recommends \
-        adb=1:8.1.0+r23-5~18.04 \
+        adb=1:7.0.0+r33-2 \
+        android-libadb=1:7.0.0+r33-2 \
+        android-libbase=1:7.0.0+r33-2 \
+        android-libcutils=1:7.0.0+r33-2 \
+        android-liblog=1:7.0.0+r33-2 \
     \
     && rm -fr \
         /tmp/* \


### PR DESCRIPTION
Signed-off-by: Franck Nijhof <frenck@addons.community>

Fixes:

```
write(2, "adb I 05-08 22:47:52  7706  7706"..., 80adb I 05-08 22:47:52  7706  7706 adb_auth_host.cpp:109] generate_key(--help)...
) = 80
futex(0x76cecb08, FUTEX_WAKE_PRIVATE, 2147483647) = 0
getrandom("\x0b", 1, GRND_NONBLOCK)     = 1
futex(0x76cec86c, FUTEX_WAKE_PRIVATE, 2147483647) = 0
getrandom("\x23\xb1\xc7\xcc\xa8\xf6\xcd\x99\xca\x14\x47\x97\x9a\x65\x71\x69\x95\xaa\x8c\xe6\xf3\xfd\x93\x87\x8c\xde\x56\x16\xfb\x02\x1a\xf8", 32, 0) = 32
futex(0x76cecc30, FUTEX_WAKE_PRIVATE, 2147483647) = 0
getrandom("\x30\xd9\x78\xaa\xad\xb0\x34\x7e\x8b\xb2\x6b\xd4\xb3\x94\x49\x62\x36\x75\x07\x1d\x60\x43\xee\x39\xcc\x1f\x5c\x27\x1d\xd3\x56\xa3"..., 48, 0) = 48
--- SIGBUS {si_signo=SIGBUS, si_code=BUS_ADRALN, si_addr=0x76cb25a1} ---
+++ killed by SIGBUS (core dumped) +++
Bus error (core dumped)
```

Cannot work around this invalid address alignment, hence a downgrade seems to be the only option for now.

Fixes #11 