### PR TITLE
🔨Change adb-connect to wait on port

### DIFF
--- a/adb/rootfs/etc/services.d/adb-connect/run
+++ b/adb/rootfs/etc/services.d/adb-connect/run
@@ -6,7 +6,7 @@
 declare path
 
 # Wait for ADB to become available
-s6-svwait -u -t 5000 /var/run/s6/services/adb
+bashio::net.wait_for 5037
 
 path="/data"
 # If the user specified a custom keys path, use that.


### PR DESCRIPTION
# Proposed Changes

Change the adb-connect service to use bashio::net.wait_for

As this is generally used in other addons, it would help standardise.

## Related Issues

Possibly #19 , although I cannot duplicate the issue, I do see the adb service starting multiple times on first run, and I believe adb-connect will attempt to launch adb if it is not running (possibly leading to the port error).
